### PR TITLE
ci(publish): separate npm and gpr into two jobs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,39 +1,37 @@
-# This workflow will do a clean install of node dependencies and publishes the package
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
 
-name: Publish package
+name: Node.js Package
 
 on:
   release:
     types: [created]
 
 jobs:
-  build:
+  publish-npm:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      # Setup .npmrc file to publish to npm
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 14.x
-          registry-url: "https://registry.npmjs.org"
+          registry-url: https://registry.npmjs.org/
           scope: "@gapit"
 
       - run: npm ci
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
-      # Setup .npmrc file to publish to GitHub Packages
+  publish-gpr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          registry-url: "https://npm.pkg.github.com"
+          registry-url: https://npm.pkg.github.com/
           scope: "@gapitio"
 
-      # Publish to GitHub Packages
+      - run: npm ci
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Makes it easier to rerun one job instead of npm and gpr together.
Also doesn't stop if one fails.